### PR TITLE
Add ability to set port via environment settings. E.g. PORT=8008

### DIFF
--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -32,7 +32,7 @@ listeners:
         compress: false
   {% endif %}
 
-  - port: 8008
+  - port: {{ PORT | default("8008", true) }}  # 8008
     tls: false
     bind_addresses: ['0.0.0.0']
     type: http


### PR DESCRIPTION
Sometimes in large installations or specific PaaS (like Heroku) you have to set port not in config but dynamically via environment settings. 